### PR TITLE
Fix the bug that Ruby highlight doesn't work

### DIFF
--- a/Markdown Extended.tmLanguage
+++ b/Markdown Extended.tmLanguage
@@ -368,6 +368,34 @@
     </dict>
     <dict>
       <key>begin</key>
+      <string>(```)\s*ruby\s*$</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.fenced.markdown</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>variable.language.fenced.markdown</string>
+        </dict>
+      </dict>
+      <key>end</key>
+      <string>(\1)\n</string>
+      <key>name</key>
+      <string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>source.ruby</string>
+        </dict>
+      </array>
+    </dict>
+    <dict>
+      <key>begin</key>
       <string>(```)\s*(json)\s*$</string>
       <key>captures</key>
       <dict>


### PR DESCRIPTION
I've opened an issue(https://github.com/jonschlinkert/sublime-markdown-extended/issues/11) for this. This patch can resolve the problem.
