### PR TITLE
Ignore cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.cache
 *.sublime-*
 tmp


### PR DESCRIPTION
Sublime Text generates `Syntaxes/Markdown Extended.tmLanguage.cache`, which ends up marking the repository as modified if a submodule.
