### PR TITLE
adding support for knitr R syntax ({r}, {r, opts}

### DIFF
--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -116,7 +116,7 @@
     </dict>
     <dict>
       <key>begin</key>
-      <string>(```)\s*r\s*$</string>
+      <string>(```)\s*\{?r(.*+)\}?\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>


### PR DESCRIPTION
This adds support for Knitr (literate coding in R) code blocks, example:

![](http://reganmian.net/files/example-of-knitr-codeblock-sublime.png)
