### PR TITLE
Fix the bug that it regard ruby syntax as r syntax after pull/26

### DIFF
--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -116,6 +116,34 @@
     </dict>
     <dict>
       <key>begin</key>
+      <string>(```)\s*ruby\s*$</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.fenced.markdown</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>variable.language.fenced.markdown</string>
+        </dict>
+      </dict>
+      <key>end</key>
+      <string>(\1)\n</string>
+      <key>name</key>
+      <string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>source.ruby</string>
+        </dict>
+      </array>
+    </dict>
+    <dict>
+      <key>begin</key>
       <string>(```)\s*\{?r(.*+)\}?\s*$</string>
       <key>captures</key>
       <dict>
@@ -591,34 +619,6 @@
         <dict>
           <key>include</key>
           <string>source.ejs</string>
-        </dict>
-      </array>
-    </dict>
-    <dict>
-      <key>begin</key>
-      <string>(```)\s*ruby\s*$</string>
-      <key>captures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>punctuation.definition.fenced.markdown</string>
-        </dict>
-        <key>2</key>
-        <dict>
-          <key>name</key>
-          <string>variable.language.fenced.markdown</string>
-        </dict>
-      </dict>
-      <key>end</key>
-      <string>(\1)\n</string>
-      <key>name</key>
-      <string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
-      <key>patterns</key>
-      <array>
-        <dict>
-          <key>include</key>
-          <string>source.ruby</string>
         </dict>
       </array>
     </dict>


### PR DESCRIPTION
I can't understand why it regards all languages whose name starts with r
as r language, and I don't know how many other languages are influenced
by it. But I must save Ruby!

Just move the Ruby part to the front. It can work.
