### PR TITLE
Support kramdown style fenced code blocks

### DIFF
--- a/Syntaxes/Markdown Extended.JSON-tmLanguage
+++ b/Syntaxes/Markdown Extended.JSON-tmLanguage
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(c)\\s*$",
+      "begin": "(```|~~~)\\s*(c)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -60,7 +60,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(cpp)\\s*$",
+      "begin": "(```|~~~)\\s*(cpp)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(coffee|coffeescript)\\s*$",
+      "begin": "(```|~~~)\\s*(coffee|coffeescript)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -96,7 +96,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(css)\\s*$",
+      "begin": "(```|~~~)\\s*(css)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -114,7 +114,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(ejs|underscore|lodash)\\s*$",
+      "begin": "(```|~~~)\\s*(ejs|underscore|lodash)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -132,7 +132,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(diff)\\s*$",
+      "begin": "(```|~~~)\\s*(diff)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(hbs|handlebars|html|html5)\\s*$",
+      "begin": "(```|~~~)\\s*(hbs|handlebars|html|html5)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -171,7 +171,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(java)\\s*$",
+      "begin": "(```|~~~)\\s*(java)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -189,7 +189,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(javascript|js)\\s*$",
+      "begin": "(```|~~~)\\s*(javascript|js)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -207,7 +207,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(json)\\s*$",
+      "begin": "(```|~~~)\\s*(json)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -225,7 +225,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(less)\\s*$",
+      "begin": "(```|~~~)\\s*(less)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -243,7 +243,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(md|markdown)\\s*$",
+      "begin": "(```|~~~)\\s*(md|markdown)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -261,7 +261,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(obj(?:ective\\-|)c)\\s*$",
+      "begin": "(```|~~~)\\s*(obj(?:ective\\-|)c)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -279,7 +279,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(obj(?:ective\\-|)c\\+\\+)\\s*$",
+      "begin": "(```|~~~)\\s*(obj(?:ective\\-|)c\\+\\+)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -297,7 +297,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(perl)\\s*$",
+      "begin": "(```|~~~)\\s*(perl)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -315,7 +315,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*ruby\\s*$",
+      "begin": "(```|~~~)\\s*ruby\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -333,7 +333,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(sass)\\s*$",
+      "begin": "(```|~~~)\\s*(sass)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -351,7 +351,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(scss)\\s*$",
+      "begin": "(```|~~~)\\s*(scss)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -369,7 +369,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(shell|bash)\\s*$",
+      "begin": "(```|~~~)\\s*(shell|bash)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -387,7 +387,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(styl)\\s*$",
+      "begin": "(```|~~~)\\s*(styl)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -405,7 +405,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(sql|ddl|dml)\\s*$",
+      "begin": "(```|~~~)\\s*(sql|ddl|dml)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -423,7 +423,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(swig|liquid)\\s*$",
+      "begin": "(```|~~~)\\s*(swig|liquid)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -441,7 +441,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(xml)\\s*$",
+      "begin": "(```|~~~)\\s*(xml)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -459,7 +459,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(yaml)\\s*$",
+      "begin": "(```|~~~)\\s*(yaml)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"
@@ -477,7 +477,7 @@
       ]
     },
     {
-      "begin": "(```)\\s*(\\w*)\\s*$",
+      "begin": "(```|~~~)\\s*(\\w*)\\s*$",
       "captures": {
         "1": {
           "name": "punctuation.definition.fenced.markdown"

--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -90,7 +90,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(c)\s*$</string>
+      <string>(```|~~~)\s*(c)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -119,7 +119,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(cpp)\s*$</string>
+      <string>(```|~~~)\s*(cpp)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -148,7 +148,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(coffee|coffeescript)\s*$</string>
+      <string>(```|~~~)\s*(coffee|coffeescript)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -177,7 +177,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(css)\s*$</string>
+      <string>(```|~~~)\s*(css)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -206,7 +206,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(ejs|underscore|lodash)\s*$</string>
+      <string>(```|~~~)\s*(ejs|underscore|lodash)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -235,7 +235,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(diff)\s*$</string>
+      <string>(```|~~~)\s*(diff)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -264,7 +264,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(go|golang)\s*$</string>
+      <string>(```|~~~)\s*(go|golang)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -293,7 +293,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(hbs|handlebars|html|html5)\s*$</string>
+      <string>(```|~~~)\s*(hbs|handlebars|html|html5)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -326,7 +326,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(java)\s*$</string>
+      <string>(```|~~~)\s*(java)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -355,7 +355,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(javascript|js)\s*$</string>
+      <string>(```|~~~)\s*(javascript|js)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -384,7 +384,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(json)\s*$</string>
+      <string>(```|~~~)\s*(json)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -413,7 +413,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(less)\s*$</string>
+      <string>(```|~~~)\s*(less)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -442,7 +442,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(md|markdown)\s*$</string>
+      <string>(```|~~~)\s*(md|markdown)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -471,7 +471,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(obj(?:ective\-|)c)\s*$</string>
+      <string>(```|~~~)\s*(obj(?:ective\-|)c)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -500,7 +500,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(obj(?:ective\-|)c\+\+)\s*$</string>
+      <string>(```|~~~)\s*(obj(?:ective\-|)c\+\+)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -529,7 +529,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(perl)\s*$</string>
+      <string>(```|~~~)\s*(perl)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -558,7 +558,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(python)\s*$</string>
+      <string>(```|~~~)\s*(python)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -587,7 +587,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(ruby)\s*$</string>
+      <string>(```|~~~)\s*(ruby)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -616,7 +616,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(sass)\s*$</string>
+      <string>(```|~~~)\s*(sass)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -645,7 +645,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(scss)\s*$</string>
+      <string>(```|~~~)\s*(scss)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -674,7 +674,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(shell|bash)\s*$</string>
+      <string>(```|~~~)\s*(shell|bash)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -703,7 +703,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(sql|ddl|dml)\s*$</string>
+      <string>(```|~~~)\s*(sql|ddl|dml)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -732,7 +732,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(styl)\s*$</string>
+      <string>(```|~~~)\s*(styl)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -761,7 +761,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(swig|liquid)\s*$</string>
+      <string>(```|~~~)\s*(swig|liquid)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -790,7 +790,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(xml)\s*$</string>
+      <string>(```|~~~)\s*(xml)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -819,7 +819,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(yaml)\s*$</string>
+      <string>(```|~~~)\s*(yaml)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -848,7 +848,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(\w*)\s*$</string>
+      <string>(```|~~~)\s*(\w*)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>


### PR DESCRIPTION
This adds support for highlighting in [kramdown style fenced code blocks](http://kramdown.gettalong.org/syntax.html#fenced-code-blocks).
