### PR TITLE
Fix #examples anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Although substantial changes have been made, thank you [@aziz](https://github.co
 
 Get [Monokai Extended](https://github.com/jonschlinkert/sublime-monokai-extended) for better highlighting.
 
-#### [Jump to Examples ↓](#examples)
+#### [Jump to Examples ↓](#markdown-enhancements)
 
 
 ## Getting Started


### PR DESCRIPTION
`#examples` target no longer exists on the page. Replaced it with `#markdown-enhancements`
