### PR TITLE
Allow `sh` as an alias to `shell` or `bash`

### DIFF
--- a/Syntaxes/Markdown Extended.JSON-tmLanguage
+++ b/Syntaxes/Markdown Extended.JSON-tmLanguage
@@ -515,7 +515,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(shell|bash)\\s*$", 
+            "begin": "(```)\\s*(sh|shell|bash)\\s*$",
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"

--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -851,7 +851,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(shell|bash)\s*$</string>
+      <string>(```)\s*(sh|shell|bash)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>


### PR DESCRIPTION
GitHub Flavored Markdown allows the "sh" language designator when using
fenced code blocks, and this essentially maps to "shell" or "bash". e.g:

``` sh
export EDITOR=vim
command git commit -asm "Initial commit."
```

Signed-off-by: David Celis me@davidcel.is
