### PR TITLE
Stop underscore highlighting in variable names

### DIFF
--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -1851,7 +1851,7 @@
     <dict>
       <key>begin</key>
       <string>(?x)
-            (\*|_)(?=\S)                         # Open
+            \W(\*|_)(?=\S)                         # Open
             (?=
               (
                   &lt;[^&gt;]*+&gt;              # HTML tags


### PR DESCRIPTION
Markdown uses underscores surrounding a piece of text to add emphasis, and this is reflected in this package by pink highlighing. However when underscores occur as part of a continuous bit of text (e.g. variable or function names), we don't want it to be highlighted. This fix ensures highlighting does not take place between underscores if the first underscore is preceeded by a word character.
