### PR TITLE
Add support for tildes code fencing

### DIFF
--- a/Syntaxes/Markdown Extended.JSON-tmLanguage
+++ b/Syntaxes/Markdown Extended.JSON-tmLanguage
@@ -62,7 +62,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(c)\\s*$", 
+            "begin": "(```|~~~)\\s*(c)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -80,7 +80,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(cpp)\\s*$", 
+            "begin": "(```|~~~)\\s*(cpp)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -98,7 +98,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(coffee|coffeescript)\\s*$", 
+            "begin": "(```|~~~)\\s*(coffee|coffeescript)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -116,7 +116,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(jade)\\s*$", 
+            "begin": "(```|~~~)\\s*(jade)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -134,7 +134,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(css)\\s*$", 
+            "begin": "(```|~~~)\\s*(css)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -152,7 +152,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(ejs|underscore|lodash)\\s*$", 
+            "begin": "(```|~~~)\\s*(ejs|underscore|lodash)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -170,7 +170,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(diff)\\s*$", 
+            "begin": "(```|~~~)\\s*(diff)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -188,7 +188,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(go|golang)\\s*$", 
+            "begin": "(```|~~~)\\s*(go|golang)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -206,7 +206,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(hbs|handlebars|html|html5)\\s*$", 
+            "begin": "(```|~~~)\\s*(hbs|handlebars|html|html5)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -227,7 +227,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(java)\\s*$", 
+            "begin": "(```|~~~)\\s*(java)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -245,7 +245,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(javascript|js)\\s*$", 
+            "begin": "(```|~~~)\\s*(javascript|js)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -263,7 +263,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(json)\\s*$", 
+            "begin": "(```|~~~)\\s*(json)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -281,7 +281,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(less)\\s*$", 
+            "begin": "(```|~~~)\\s*(less)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -299,7 +299,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(ls|livescript|LiveScript)\\s*$", 
+            "begin": "(```|~~~)\\s*(ls|livescript|LiveScript)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -317,7 +317,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(lua)\\s*$", 
+            "begin": "(```|~~~)\\s*(lua)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -335,7 +335,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(md|markdown)\\s*$", 
+            "begin": "(```|~~~)\\s*(md|markdown)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -353,7 +353,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(swift)\\s*$",
+            "begin": "(```|~~~)\\s*(swift)\\s*$",
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -371,7 +371,7 @@
             ]
         },
         {
-            "begin": "(```)\\s*(obj(?:ective\\-|)c)\\s*$", 
+            "begin": "(```|~~~)\\s*(obj(?:ective\\-|)c)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -389,7 +389,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(obj(?:ective\\-|)c\\+\\+)\\s*$", 
+            "begin": "(```|~~~)\\s*(obj(?:ective\\-|)c\\+\\+)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -407,7 +407,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(perl)\\s*$", 
+            "begin": "(```|~~~)\\s*(perl)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -425,7 +425,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(php)\\s*$", 
+            "begin": "(```|~~~)\\s*(php)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -443,7 +443,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(python)\\s*$", 
+            "begin": "(```|~~~)\\s*(python)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -461,7 +461,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(ruby)\\s*$", 
+            "begin": "(```|~~~)\\s*(ruby)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -479,7 +479,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(rust)\\s*$", 
+            "begin": "(```|~~~)\\s*(rust)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -497,7 +497,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(sass)\\s*$", 
+            "begin": "(```|~~~)\\s*(sass)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -515,7 +515,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(scala)\\s*$", 
+            "begin": "(```|~~~)\\s*(scala)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -533,7 +533,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(scss)\\s*$", 
+            "begin": "(```|~~~)\\s*(scss)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -551,7 +551,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(sh|shell|bash)\\s*$",
+            "begin": "(```|~~~)\\s*(sh|shell|bash)\\s*$",
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -569,7 +569,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(sql|ddl|dml)\\s*$", 
+            "begin": "(```|~~~)\\s*(sql|ddl|dml)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -587,7 +587,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(styl)\\s*$", 
+            "begin": "(```|~~~)\\s*(styl)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -605,7 +605,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(swig|liquid)\\s*$", 
+            "begin": "(```|~~~)\\s*(swig|liquid)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -623,7 +623,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(xml)\\s*$", 
+            "begin": "(```|~~~)\\s*(xml)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -641,7 +641,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(yaml)\\s*$", 
+            "begin": "(```|~~~)\\s*(yaml)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"
@@ -659,7 +659,7 @@
             ]
         }, 
         {
-            "begin": "(```)\\s*(\\w*)\\s*$", 
+            "begin": "(```|~~~)\\s*(\\w*)\\s*$", 
             "captures": {
                 "1": {
                     "name": "punctuation.definition.fenced.markdown"

--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -122,7 +122,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(c)\s*$</string>
+      <string>(```|~~~)\s*(c)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -151,7 +151,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(cpp)\s*$</string>
+      <string>(```|~~~)\s*(cpp)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -180,7 +180,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(coffee|coffeescript)\s*$</string>
+      <string>(```|~~~)\s*(coffee|coffeescript)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -209,7 +209,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(jade)\s*$</string>
+      <string>(```|~~~)\s*(jade)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -238,7 +238,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(css)\s*$</string>
+      <string>(```|~~~)\s*(css)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -267,7 +267,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(ejs|underscore|lodash)\s*$</string>
+      <string>(```|~~~)\s*(ejs|underscore|lodash)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -296,7 +296,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(diff)\s*$</string>
+      <string>(```|~~~)\s*(diff)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -325,7 +325,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(go|golang)\s*$</string>
+      <string>(```|~~~)\s*(go|golang)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -354,7 +354,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(hbs|handlebars|html|html5)\s*$</string>
+      <string>(```|~~~)\s*(hbs|handlebars|html|html5)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -387,7 +387,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(java)\s*$</string>
+      <string>(```|~~~)\s*(java)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -416,7 +416,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(javascript|js)\s*$</string>
+      <string>(```|~~~)\s*(javascript|js)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -445,7 +445,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(json)\s*$</string>
+      <string>(```|~~~)\s*(json)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -474,7 +474,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(less)\s*$</string>
+      <string>(```|~~~)\s*(less)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -503,7 +503,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(ls|livescript|LiveScript)\s*$</string>
+      <string>(```|~~~)\s*(ls|livescript|LiveScript)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -532,7 +532,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(lua)\s*$</string>
+      <string>(```|~~~)\s*(lua)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -561,7 +561,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(md|markdown)\s*$</string>
+      <string>(```|~~~)\s*(md|markdown)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -590,7 +590,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(swift)\s*$</string>
+      <string>(```|~~~)\s*(swift)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -619,7 +619,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(obj(?:ective\-|)c)\s*$</string>
+      <string>(```|~~~)\s*(obj(?:ective\-|)c)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -648,7 +648,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(obj(?:ective\-|)c\+\+)\s*$</string>
+      <string>(```|~~~)\s*(obj(?:ective\-|)c\+\+)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -677,7 +677,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(perl)\s*$</string>
+      <string>(```|~~~)\s*(perl)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -706,7 +706,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(php)\s*$</string>
+      <string>(```|~~~)\s*(php)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -735,7 +735,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(python)\s*$</string>
+      <string>(```|~~~)\s*(python)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -764,7 +764,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*\{?\s*(r)(?:[ \}].*$|\}?$)</string>
+      <string>(```|~~~)\s*\{?\s*(r)(?:[ \}].*$|\}?$)</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -793,7 +793,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(ruby)\s*$</string>
+      <string>(```|~~~)\s*(ruby)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -822,7 +822,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(rust)\s*$</string>
+      <string>(```|~~~)\s*(rust)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -851,7 +851,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(sass)\s*$</string>
+      <string>(```|~~~)\s*(sass)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -880,7 +880,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(scala)\s*$</string>
+      <string>(```|~~~)\s*(scala)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -909,7 +909,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(scss)\s*$</string>
+      <string>(```|~~~)\s*(scss)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -938,7 +938,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(sh|shell|bash)\s*$</string>
+      <string>(```|~~~)\s*(sh|shell|bash)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -967,7 +967,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(sql|ddl|dml)\s*$</string>
+      <string>(```|~~~)\s*(sql|ddl|dml)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -996,7 +996,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(styl)\s*$</string>
+      <string>(```|~~~)\s*(styl)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -1025,7 +1025,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(swig|liquid)\s*$</string>
+      <string>(```|~~~)\s*(swig|liquid)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -1054,7 +1054,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(xml)\s*$</string>
+      <string>(```|~~~)\s*(xml)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -1083,7 +1083,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(yaml)\s*$</string>
+      <string>(```|~~~)\s*(yaml)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -1112,7 +1112,7 @@
 
     <dict>
       <key>begin</key>
-      <string>(```)\s*(\w*)\s*$</string>
+      <string>(```|~~~)\s*(\w*)\s*$</string>
       <key>captures</key>
       <dict>
         <key>1</key>


### PR DESCRIPTION
This adds support to using `~~~` for code fencing. It's used in both Github Flavored Markdown and CommonMark.