### PR TITLE
Add support for PgSQL (PostgreSQL) syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Note that in order for a language to be highlighted properly, you must have the 
 * `shell`
 * `bash`
 * `sql|ddl|dml`
+* `postgresql|postgres|pgsql`
 * `styl`
 * `swift`
 * `swig`

--- a/Syntaxes/Markdown Extended.JSON-tmLanguage
+++ b/Syntaxes/Markdown Extended.JSON-tmLanguage
@@ -587,6 +587,24 @@
             ]
         }, 
         {
+            "begin": "(```|~~~)\\s*(postgresql|postgres|pgsql)\\s*$",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.fenced.markdown"
+                },
+                "2": {
+                    "name": "variable.language.fenced.markdown"
+                }
+            },
+            "end": "(\\1)\\n",
+            "name": "markup.raw.block.markdown markup.raw.block.fenced.markdown",
+            "patterns": [
+                {
+                    "include": "source.pgsql"
+                }
+            ]
+        },
+        {
             "begin": "(```|~~~)\\s*(styl)\\s*$", 
             "captures": {
                 "1": {

--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -996,6 +996,35 @@
 
     <dict>
       <key>begin</key>
+      <string>(```|~~~)\s*(postgresql|postgres|pgsql)\s*$</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.fenced.markdown</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>variable.language.fenced.markdown</string>
+        </dict>
+      </dict>
+      <key>end</key>
+      <string>(\1)\n</string>
+      <key>name</key>
+      <string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>source.pgsql</string>
+        </dict>
+      </array>
+    </dict>
+
+    <dict>
+      <key>begin</key>
       <string>(```|~~~)\s*(styl)\s*$</string>
       <key>captures</key>
       <dict>


### PR DESCRIPTION
This adds support for highlighting the Postgres variant of SQL if the
relevant Sublime Text package is installed.

Signed-off-by: David Celis <me@davidcel.is>