### PR TITLE
Add the sublime-syntax of build 3103

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.cache
-*.sublime-*
 tmp

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -13,7 +13,7 @@ contexts:
   main:
     - match: (?<!\s)---\n$
       push:
-        - meta_scope: markup.raw.yaml.front-matter
+        - meta_scope: source.yaml markup.raw.yaml.front-matter
         - match: ^---\s
           pop: true
         - include: scope:source.yaml
@@ -698,6 +698,7 @@ contexts:
     - match: '^(?=\S)(?![=-]{3,}(?=$))'
       push:
         - meta_scope: meta.paragraph.markdown
+        - include: html_comment
         - match: '^(?:\s*$|(?=[ ]{,3}>.))|(?=[ \t]*\n)(?<=^===|^====|=====|^---|^----|-----)[ \t]*\n|(?=^#)'
           pop: true
         - include: inline
@@ -710,6 +711,16 @@ contexts:
           scope: markup.heading.2.markdown
           captures:
             1: punctuation.definition.heading.markdown
+  html_comment:
+    - match: <!--
+      captures:
+        0: punctuation.definition.comment.html
+      push:
+        - meta_scope: comment.block.html
+        - match: '--\s*>'
+          pop: true
+        - match: "--"
+          scope: invalid.illegal.bad-comments-or-CDATA.html
   ampersand:
     - match: "&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)"
       comment: |

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -1,0 +1,1197 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Markdown Extended
+file_extensions:
+  - mdown
+  - markdown
+  - markdn
+  - md.hbs
+  - md
+scope: text.html.markdown
+contexts:
+  main:
+    - match: (?<!\s)---\n$
+      push:
+        - meta_scope: markup.raw.yaml.front-matter
+        - match: ^---\s
+          pop: true
+        - include: scope:source.yaml
+    - match: (?<!\s)---\s*coffee\n$
+      push:
+        - meta_scope: markup.raw.coffee.front-matter
+        - match: ^---\s
+          pop: true
+        - include: scope:source.coffee
+    - match: (?<!\s)---\s*json\n$
+      push:
+        - meta_scope: markup.raw.json.front-matter
+        - match: ^---\s
+          pop: true
+        - include: scope:source.json
+    - match: |-
+        (?x)^
+        (?= [ ]{,3}>.
+        | ([ ]{4}|\t)(?!$)
+        | [#]{1,6}\s*+
+        | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+        )
+      comment: |
+        We could also use an empty end match and set
+                applyEndPatternLast, but then we must be sure that the begin
+                pattern will only match stuff matched by the sub-patterns.
+      push:
+        - meta_scope: meta.block-level.markdown
+        - match: |-
+            (?x)^
+            (?! [ ]{,3}>.
+            | ([ ]{4}|\t)
+            | [#]{1,6}\s*+
+            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            )
+          pop: true
+        - include: block_quote
+        - include: block_raw
+        - include: heading
+        - include: separator
+    - match: '(```|~~~|{%\s*highlight)\s*(c)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.c
+    - match: '(```|~~~|{%\s*highlight)\s*(cpp)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.c++
+    - match: '(```|~~~|{%\s*highlight)\s*(coffee|coffeescript)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.coffee
+    - match: '(```|~~~|{%\s*highlight)\s*(jade)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.jade
+    - match: '(```|~~~|{%\s*highlight)\s*(css)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.css
+    - match: '(```|~~~|{%\s*highlight)\s*(csharp)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.cs
+    - match: '(```|~~~|{%\s*highlight)\s*(ejs|underscore|lodash)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.ejs
+    - match: '(```|~~~|{%\s*highlight)\s*(erlang)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.erlang
+    - match: '(```|~~~|{%\s*highlight)\s*(diff)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.diff
+    - match: '(```|~~~|{%\s*highlight)\s*(go|golang)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.go
+    - match: '(```|~~~|{%\s*highlight)\s*(hbs|handlebars|html|html5)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:text.html.basic
+        - include: scope:text.html.handlebars
+    - match: '(```|~~~|{%\s*highlight)\s*(ini)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.ini
+    - match: '(```|~~~|{%\s*highlight)\s*(java)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.java
+    - match: '(```|~~~|{%\s*highlight)\s*(javascript|js)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.js
+    - match: '(```|~~~|{%\s*highlight)\s*(json)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.json
+    - match: '(```|{%\s*highlight)\s*(julia|jl)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.julia
+    - match: '(```|{%\s*highlight)\s*(less)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.css.less
+    - match: '(```|~~~|{%\s*highlight)\s*(ls|livescript|LiveScript)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.livescript
+    - match: '(```|~~~|{%\s*highlight)\s*(lua)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.lua
+    - match: '(```|~~~|{%\s*highlight)\s*(md|markdown)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:text.html.markdown
+    - match: '(```|~~~|{%\s*highlight)\s*(nginx)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.nginx
+    - match: '(```|~~~|{%\s*highlight)\s*(swift)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.swift
+    - match: '(```|~~~|{%\s*highlight)\s*(obj(?:ective\-|)c)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.objc
+    - match: '(```|~~~|{%\s*highlight)\s*(obj(?:ective\-|)c\+\+)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.objc++
+    - match: '(```|~~~|{%\s*highlight)\s*(perl)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.perl
+    - match: '(```|~~~|{%\s*highlight)\s*(php)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.php
+    - match: '(```|~~~|{%\s*highlight)\s*(python)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.python
+    - match: '(```|~~~)\s*\{?\s*(r)(?:[ \}].*$|\}?$)'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.r
+    - match: '(```|~~~|{%\s*highlight)\s*(ruby)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.ruby
+    - match: '(```|~~~|{%\s*highlight)\s*(rust)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.rust
+    - match: '(```|~~~|{%\s*highlight)\s*(sass)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.sass
+    - match: '(```|~~~|{%\s*highlight)\s*(scala)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.scala
+    - match: '(```|~~~|{%\s*highlight)\s*(scss)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.scss
+    - match: '(```|~~~|{%\s*highlight)\s*(sh|shell|bash)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.shell
+    - match: '(```|~~~|{%\s*highlight)\s*(sql|mysql|ddl|dml)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.sql
+    - match: '(```|~~~|{%\s*highlight)\s*(postgresql|postgres|pgsql)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.pgsql
+    - match: '(```|~~~|{%\s*highlight)\s*(styl)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.stylus
+    - match: '(```|~~~|{%\s*highlight)\s*(swig|liquid)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:text.html.swig
+    - match: '(```|~~~|{%\s*highlight)\s*(xml)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:text.xml
+    - match: '(```|~~~|{%\s*highlight)\s*(yaml)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.yaml
+    - match: '(```|~~~|{%\s*highlight)\s*(\w*)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+    - match: '^[ ]{0,3}([*+-])(?=\s)'
+      captures:
+        1: punctuation.definition.list_item.markdown
+      push:
+        - meta_scope: markup.list.unnumbered.markdown
+        - match: ^(?=\S)
+          captures:
+            1: punctuation.definition.list_item.markdown
+          pop: true
+        - include: list-paragraph
+    - match: '^[ ]{0,3}([0-9]+)(\.)(?=\s)'
+      captures:
+        1: punctuation.definition.list_item.markdown punctuation.definition.list_item.number.markdown
+        2: punctuation.definition.list_item.markdown
+      push:
+        - meta_scope: markup.list.numbered.markdown
+        - match: ^(?=\S)
+          captures:
+            1: punctuation.definition.list_item.markdown punctuation.definition.list_item.number.markdown
+            2: punctuation.definition.list_item.markdown
+          pop: true
+        - include: list-paragraph
+    - match: '^(?=<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del)\b)(?!.*?</\1>)'
+      comment: Markdown formatting is disabled inside block-level tags.
+      push:
+        - meta_scope: meta.disable-markdown
+        - match: (?<=^</\1>$\n)
+          pop: true
+        - include: scope:text.html.basic
+        - include: scope:text.html.handlebars
+    - match: '^(?=<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del)\b)'
+      comment: Same rule but for one line disables.
+      push:
+        - meta_scope: meta.disable-markdown
+        - match: $\n?
+          pop: true
+        - include: scope:text.html.basic
+        - include: scope:text.html.handlebars
+    - match: |-
+        (?x:
+          \s*           # Leading whitespace
+          (\[)(.+?)(\])(:)    # Reference name
+          [ \t]*          # Optional whitespace
+          (<?)(\S+?)(>?)      # The url
+          [ \t]*          # Optional whitespace
+          (?:
+              ((\().+?(\)))   # Match title in quotes…
+            | ((").+?("))   # or in parens.
+          )?            # Title is optional
+          \s*           # Optional whitespace
+          $
+        )
+      scope: meta.link.reference.def.markdown
+      captures:
+        1: punctuation.definition.constant.markdown
+        2: constant.other.reference.link.markdown
+        3: punctuation.definition.constant.markdown
+        4: punctuation.separator.key-value.markdown
+        5: punctuation.definition.link.markdown
+        6: markup.underline.link.markdown
+        7: punctuation.definition.link.markdown
+        8: string.other.link.description.title.markdown
+        9: punctuation.definition.string.begin.markdown
+        10: punctuation.definition.string.end.markdown
+        11: string.other.link.description.title.markdown
+        12: punctuation.definition.string.begin.markdown
+        13: punctuation.definition.string.end.markdown
+    - match: '^(?=\S)(?![=-]{3,}(?=$))'
+      push:
+        - meta_scope: meta.paragraph.markdown
+        - match: '^(?:\s*$|(?=[ ]{,3}>.))|(?=[ \t]*\n)(?<=^===|^====|=====|^---|^----|-----)[ \t]*\n|(?=^#)'
+          pop: true
+        - include: inline
+        - include: scope:text.html.handlebars
+        - match: '^(={3,})(?=[ \t]*$)'
+          scope: markup.heading.1.markdown
+          captures:
+            1: punctuation.definition.heading.markdown
+        - match: '^(-{3,})(?=[ \t]*$)'
+          scope: markup.heading.2.markdown
+          captures:
+            1: punctuation.definition.heading.markdown
+  ampersand:
+    - match: "&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)"
+      comment: |
+        Markdown will convert this for us. We match it so that the
+                HTML grammar will not mark it up as invalid.
+      scope: meta.other.valid-ampersand.markdown
+  block_quote:
+    - match: '\G[ ]{,3}(>)(?!$)[ ]?'
+      comment: |
+        We terminate the block quote when seeing an empty line, a
+                separator or a line with leading > characters. The latter is
+                to “reset” the quote level for quoted lines.
+      captures:
+        1: punctuation.definition.blockquote.markdown
+      push:
+        - meta_scope: markup.quote.markdown
+        - match: |-
+            (?x)^
+            (?= \s*$
+            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            | [ ]{,3}>.
+            )
+          pop: true
+        - match: |-
+            (?x)\G
+            (?= [ ]{,3}>.
+            )
+          push:
+            - match: ^
+              pop: true
+            - include: block_quote
+        - match: |-
+            (?x)\G
+            (?= ([ ]{4}|\t)
+            | [#]{1,6}\s*+
+            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            )
+          push:
+            - include: block_raw
+            - include: heading
+            - include: separator
+            - match: ^
+              pop: true
+        - match: |-
+            (?x)\G
+            (?! $
+            | [ ]{,3}>.
+            | ([ ]{4}|\t)
+            | [#]{1,6}\s*+
+            | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            )
+          push:
+            - match: $|(?<=\n)
+              pop: true
+            - include: inline
+  block_raw:
+    - match: '\G([ ]{4}|\t).*$\n?'
+      scope: markup.raw.block.markdown
+  bold:
+    - match: |-
+        (?x)
+        (\*\*|__)(?=\S)               # Open
+        (?=
+          (
+              <[^>]*+>             # HTML tags
+            | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
+                              # Raw
+            | \\[\\`*_{}\[\]()#.!+\->]?+     # Escapes
+            | \[
+            (
+                    (?<square>          # Named group
+                  [^\[\]\\]       # Match most chars
+                      | \\.           # Escaped chars
+                      | \[ \g<square>*+ \]    # Nested brackets
+                    )*+
+              \]
+              (
+                (             # Reference Link
+                  [ ]?          # Optional space
+                  \[[^\]]*+\]       # Ref name
+                )
+                | (             # Inline Link
+                  \(            # Opening paren
+                    [ \t]*+       # Optional whtiespace
+                    <?(.*?)>?     # URL
+                    [ \t]*+       # Optional whtiespace
+                    (         # Optional Title
+                      (?<title>['"])
+                      (.*?)
+                      \k<title>
+                    )?
+                  \)
+                )
+              )
+            )
+            | (?!(?<=\S)\1).           # Everything besides
+                              # style closer
+          )++
+          (?<=\S)\1                # Close
+        )
+      captures:
+        1: punctuation.definition.bold.markdown
+      push:
+        - meta_scope: markup.bold.markdown
+        - match: (?<=\S)(\1)
+          captures:
+            1: punctuation.definition.bold.markdown
+          pop: true
+        - match: "(?=<[^>]*?>)"
+          push:
+            - include: scope:text.html.handlebars
+            - match: (?<=>)
+              pop: true
+        - include: escape
+        - include: ampersand
+        - include: bracket
+        - include: raw
+        - include: italic
+        - include: strike
+        - include: image-inline
+        - include: link-inline
+        - include: link-inet
+        - include: link-email
+        - include: image-ref
+        - include: link-ref-literal
+        - include: link-ref
+  bracket:
+    - match: '<(?![a-z/?\$!])'
+      comment: |
+        Markdown will convert this for us. We match it so that the
+                HTML grammar will not mark it up as invalid.
+      scope: meta.other.valid-bracket.markdown
+  escape:
+    - match: '\\[-`*_#+.!(){}\[\]\\>]'
+      scope: constant.character.escape.markdown
+  heading:
+    - match: '\G(#{1})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.markdown
+      push:
+        - meta_scope: markup.heading.1.markdown
+        - meta_content_scope: markup.heading.1.markdown
+        - match: \s*(#*)$\n?
+          captures:
+            1: punctuation.definition.heading.markdown
+          pop: true
+        - include: inline
+    - match: '\G(#{2})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.markdown
+      push:
+        - meta_scope: markup.heading.2.markdown
+        - meta_content_scope: markup.heading.2.markdown
+        - match: \s*(#*)$\n?
+          captures:
+            1: punctuation.definition.heading.markdown
+          pop: true
+        - include: inline
+    - match: '\G(#{3})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.markdown
+      push:
+        - meta_scope: markup.heading.3.markdown
+        - meta_content_scope: markup.heading.3.markdown
+        - match: \s*(#*)$\n?
+          captures:
+            1: punctuation.definition.heading.markdown
+          pop: true
+        - include: inline
+    - match: '\G(#{4})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.markdown
+      push:
+        - meta_scope: markup.heading.4.markdown
+        - meta_content_scope: markup.heading.4.markdown
+        - match: \s*(#*)$\n?
+          captures:
+            1: punctuation.definition.heading.markdown
+          pop: true
+        - include: inline
+    - match: '\G(#{5})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.markdown
+      push:
+        - meta_scope: markup.heading.5.markdown
+        - meta_content_scope: markup.heading.5.markdown
+        - match: \s*(#*)$\n?
+          captures:
+            1: punctuation.definition.heading.markdown
+          pop: true
+        - include: inline
+    - match: '\G(#{6})(?!#)\s*(?=\S)'
+      captures:
+        1: punctuation.definition.heading.markdown
+      push:
+        - meta_scope: markup.heading.6.markdown
+        - meta_content_scope: markup.heading.6.markdown
+        - match: \s*(#*)$\n?
+          captures:
+            1: punctuation.definition.heading.markdown
+          pop: true
+        - include: inline
+  image-inline:
+    - match: |-
+        (?x:
+         \!              # Images start with !
+         (\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])
+                       # Match the link text.
+         ([ ])?            # Space not allowed
+         (\()            # Opening paren for url
+           (<?)(\S+?)(>?)      # The url
+           [ \t]*          # Optional whitespace
+           (?:
+               ((\().+?(\)))   # Match title in parens…
+             | ((").+?("))   # or in quotes.
+           )?            # Title is optional
+           \s*           # Optional whitespace
+         (\))
+        )
+      scope: meta.image.inline.markdown
+      captures:
+        1: punctuation.definition.string.begin.markdown
+        2: string.other.link.description.markdown
+        4: punctuation.definition.string.end.markdown
+        5: invalid.illegal.whitespace.markdown
+        6: punctuation.definition.metadata.markdown
+        7: punctuation.definition.link.markdown
+        8: markup.underline.link.image.markdown
+        9: punctuation.definition.link.markdown
+        10: string.other.link.description.title.markdown
+        11: punctuation.definition.string.markdown
+        12: punctuation.definition.string.markdown
+        13: string.other.link.description.title.markdown
+        14: punctuation.definition.string.markdown
+        15: punctuation.definition.string.markdown
+        16: punctuation.definition.metadata.markdown
+  image-ref:
+    - match: '\!(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(.*?)(\])'
+      scope: meta.image.reference.markdown
+      captures:
+        1: punctuation.definition.string.begin.markdown
+        2: string.other.link.description.markdown
+        4: punctuation.definition.string.begin.markdown
+        5: punctuation.definition.constant.markdown
+        6: constant.other.reference.link.markdown
+        7: punctuation.definition.constant.markdown
+  inline:
+    - include: escape
+    - include: ampersand
+    - include: bracket
+    - include: raw
+    - include: bold
+    - include: italic
+    - include: strike
+    - include: line-break
+    - include: image-inline
+    - include: link-inline
+    - include: link-inet
+    - include: link-email
+    - include: image-ref
+    - include: link-ref-literal
+    - include: link-ref
+  italic:
+    - match: |-
+        (?x)
+        (\*|_)(?=\S)                         # Open
+        (?=
+          (
+              <[^>]*+>              # HTML tags
+            | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
+                                             # Raw
+            | \\[\\`*_{}\[\]()#.!+\->]?+  # Escapes
+            | \[
+            (
+                    (?<square>         # Named group
+                  [^\[\]\\]                  # Match most chars
+                      | \\.                  # Escaped chars
+                      | \[ \g<square>*+ \]  # Nested brackets
+                    )*+
+              \]
+              (
+                (                            # Reference Link
+                  [ ]?                       # Optional space
+                  \[[^\]]*+\]                # Ref name
+                )
+                | (                          # Inline Link
+                  \(                         # Opening paren
+                    [ \t]*+                  # Optional whtiespace
+                    <?(.*?)>?          # URL
+                    [ \t]*+                  # Optional whtiespace
+                    (                        # Optional Title
+                      (?<title>['"])
+                      (.*?)
+                      \k<title>
+                    )?
+                  \)
+                )
+              )
+            )
+            | \1\1                        # Must be bold closer
+            | (?!(?<=\S)\1).           # Everything besides
+                                          # style closer
+          )++
+          (?<=\S)\1                    # Close
+        )
+      captures:
+        1: punctuation.definition.italic.markdown
+      push:
+        - meta_scope: markup.italic.markdown
+        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+          captures:
+            1: punctuation.definition.italic.markdown
+          pop: true
+        - match: "(?=<[^>]*?>)"
+          push:
+            - include: scope:text.html.handlebars
+            - match: (?<=>)
+              pop: true
+        - include: escape
+        - include: ampersand
+        - include: bracket
+        - include: raw
+        - include: bold
+        - include: strike
+        - include: image-inline
+        - include: link-inline
+        - include: link-inet
+        - include: link-email
+        - include: image-ref
+        - include: link-ref-literal
+        - include: link-ref
+  line-break:
+    - match: " {2,}$"
+      scope: meta.dummy.line-break
+  link-email:
+    - match: '(<)((?:mailto:)?[-.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)'
+      scope: meta.link.email.lt-gt.markdown
+      captures:
+        1: punctuation.definition.link.markdown
+        2: markup.underline.link.markdown
+        4: punctuation.definition.link.markdown
+  link-inet:
+    - match: (<)((?:https?|ftp)://.*?)(>)
+      scope: meta.link.inet.markdown
+      captures:
+        1: punctuation.definition.link.markdown
+        2: markup.underline.link.markdown
+        3: punctuation.definition.link.markdown
+  link-inline:
+    - match: |-
+        (?x:
+         (\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])
+                       # Match the link text.
+         ([ ])?            # Space not allowed
+         (\()            # Opening paren for url
+           (<?)(.*?)(>?)     # The url
+           [ \t]*          # Optional whitespace
+           (?:
+               ((\().+?(\)))   # Match title in parens…
+             | ((").+?("))   # or in quotes.
+           )?            # Title is optional
+           \s*           # Optional whitespace
+         (\))
+        )
+      scope: meta.link.inline.markdown
+      captures:
+        1: punctuation.definition.string.begin.markdown
+        2: string.other.link.title.markdown
+        4: punctuation.definition.string.end.markdown
+        5: invalid.illegal.whitespace.markdown
+        6: punctuation.definition.metadata.markdown
+        7: punctuation.definition.link.markdown
+        8: markup.underline.link.markdown
+        9: punctuation.definition.link.markdown
+        10: string.other.link.description.title.markdown
+        11: punctuation.definition.string.begin.markdown
+        12: punctuation.definition.string.end.markdown
+        13: string.other.link.description.title.markdown
+        14: punctuation.definition.string.begin.markdown
+        15: punctuation.definition.string.end.markdown
+        16: punctuation.definition.metadata.markdown
+  link-ref:
+    - match: '(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)([^\]]*+)(\])'
+      scope: meta.link.reference.markdown
+      captures:
+        1: punctuation.definition.string.begin.markdown
+        2: string.other.link.title.markdown
+        4: punctuation.definition.string.end.markdown
+        5: punctuation.definition.constant.begin.markdown
+        6: constant.other.reference.link.markdown
+        7: punctuation.definition.constant.end.markdown
+  link-ref-literal:
+    - match: '(\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])[ ]?(\[)(\])'
+      scope: meta.link.reference.literal.markdown
+      captures:
+        1: punctuation.definition.string.begin.markdown
+        2: string.other.link.title.markdown
+        4: punctuation.definition.string.end.markdown
+        5: punctuation.definition.constant.begin.markdown
+        6: punctuation.definition.constant.end.markdown
+  list-paragraph:
+    - match: \G\s+(?=\S)
+      push:
+        - meta_scope: meta.paragraph.list.markdown
+        - match: ^\s*$
+          pop: true
+        - include: inline
+  raw:
+    - match: '(`+)([^`]|(?!(?<!`)\1(?!`))`)*+(\1)'
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.markdown
+        3: punctuation.definition.raw.markdown
+  separator:
+    - match: '\G[ ]{,3}([-*_])([ ]{,2}\1){2,}[ \t]*$\n?'
+      scope: meta.separator.markdown
+  strike:
+    - match: |-
+        (?x)
+        (~~)(?=\S)                         # Open
+        (?=
+          (
+              <[^>]*+>              # HTML tags
+            | (?<raw>`+)([^`]|(?!(?<!`)\k<raw>(?!`))`)*+\k<raw>
+                                             # Raw
+            | \\[\\`*_{}\[\]()#.!+\->]?+  # Escapes
+            | \[
+            (
+                    (?<square>         # Named group
+                  [^\[\]\\]                  # Match most chars
+                      | \\.                  # Escaped chars
+                      | \[ \g<square>*+ \]  # Nested brackets
+                    )*+
+              \]
+              (
+                (                            # Reference Link
+                  [ ]?                       # Optional space
+                  \[[^\]]*+\]                # Ref name
+                )
+                | (                          # Inline Link
+                  \(                         # Opening paren
+                    [ \t]*+                  # Optional whtiespace
+                    <?(.*?)>?          # URL
+                    [ \t]*+                  # Optional whtiespace
+                    (                        # Optional Title
+                      (?<title>['"])
+                      (.*?)
+                      \k<title>
+                    )?
+                  \)
+                )
+              )
+            )
+            | \1\1                        # Must be bold closer
+            | (?!(?<=\S)\1).           # Everything besides
+                                          # style closer
+          )++
+          (?<=\S)\1                    # Close
+        )
+      captures:
+        1: punctuation.definition.strike.markdown
+      push:
+        - meta_scope: markup.strike.markdown
+        - match: (?<=\S)(\1)((?!\1)|(?=\1\1))
+          captures:
+            1: punctuation.definition.strike.markdown
+          pop: true
+        - match: "(?=<[^>]*?>)"
+          push:
+            - include: scope:text.html.handlebars
+            - match: (?<=>)
+              pop: true
+        - include: escape
+        - include: ampersand
+        - include: bracket
+        - include: raw
+        - include: bold
+        - include: italic
+        - include: image-inline
+        - include: link-inline
+        - include: link-inet
+        - include: link-email
+        - include: image-ref
+        - include: link-ref-literal
+        - include: link-ref

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -658,6 +658,7 @@ contexts:
           pop: true
         - include: scope:text.html.basic
         - include: scope:text.html.handlebars
+        - include: latex
     - match: '^(?=<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del)\b)'
       comment: Same rule but for one line disables.
       push:
@@ -983,6 +984,7 @@ contexts:
     - include: image-ref
     - include: link-ref-literal
     - include: link-ref
+    - include: latex
   italic:
     - match: |-
         (?x)
@@ -1206,3 +1208,18 @@ contexts:
         - include: image-ref
         - include: link-ref-literal
         - include: link-ref
+  latex:
+    - match: (?=\$\$)
+      push:
+        - meta_scope: text.tex.latex
+        - match: (?<=\$\$)
+          pop: true
+        - include: scope:text.tex.latex
+    - match: (?=(\$(?!\$)).*?\S\$)
+      with_prototype:
+        - match: \s$
+      push:
+        - meta_scope: text.tex.latex
+        - match: (?<=\S\$|\n)
+          pop: true
+        - include: scope:text.tex.latex

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -19,13 +19,13 @@ contexts:
         - include: scope:source.yaml
     - match: (?<!\s)---\s*coffee\n$
       push:
-        - meta_scope: markup.raw.coffee.front-matter
+        - meta_scope: source.coffee markup.raw.coffee.front-matter
         - match: ^---\s
           pop: true
         - include: scope:source.coffee
     - match: (?<!\s)---\s*json\n$
       push:
-        - meta_scope: markup.raw.json.front-matter
+        - meta_scope: source.json markup.raw.json.front-matter
         - match: ^---\s
           pop: true
         - include: scope:source.json
@@ -61,6 +61,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.c
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -75,6 +76,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.c++
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -89,6 +91,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.coffee
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -103,6 +106,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.jade
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -117,6 +121,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.css
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -131,6 +136,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.cs
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -145,6 +151,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.ejs
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -159,6 +166,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.erlang
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -173,6 +181,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.diff
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -187,6 +196,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.go
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -201,6 +211,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: text.html.basic
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -216,6 +227,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.ini
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -230,6 +242,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.java
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -244,6 +257,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.js
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -258,6 +272,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.json
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -272,6 +287,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.julia
         - match: '(```|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -286,6 +302,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.css.less
         - match: '(```|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -300,6 +317,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.livescript
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -314,6 +332,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.lua
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -328,6 +347,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: text.html.markdown
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -342,6 +362,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.nginx
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -356,6 +377,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.swift
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -370,6 +392,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.objc
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -384,6 +407,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.objc++
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -398,6 +422,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.perl
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -412,6 +437,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.php
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -426,6 +452,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.python
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -440,6 +467,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.r
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -454,6 +482,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.ruby
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -468,6 +497,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.rust
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -482,6 +512,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.sass
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -496,6 +527,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.scala
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -510,6 +542,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.scss
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -524,6 +557,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.shell
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -538,6 +572,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.sql
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -552,6 +587,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.pgsql
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -566,6 +602,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.stylus
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -580,6 +617,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: text.html.swig
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -594,6 +632,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: text.xml
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown
@@ -608,6 +647,7 @@ contexts:
         3: punctuation.definition.fenced.markdown
       push:
         - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.yaml
         - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
           captures:
             1: punctuation.definition.fenced.markdown

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -460,7 +460,7 @@ contexts:
             3: punctuation.definition.fenced.markdown
           pop: true
         - include: scope:source.python
-    - match: '(```|~~~)\s*\{?\s*(r)(?:[ \}].*$|\}?$)'
+    - match: '(```|~~~)\s*\{?\s*(r)(?:[ \},].*$|\}?$)'
       captures:
         1: punctuation.definition.fenced.markdown
         2: variable.language.fenced.markdown


### PR DESCRIPTION
Besides adding the .sublime-syntax file which is supported by build 3103, I have also improved the followings.

- it is now possible to comment, fix #92 
- add latex math support, fix #105, it is only possible with the new sublime-syntax format
- improve r fenced code