### PR TITLE
improve latex and fix --- separator issue

### DIFF
--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -1260,9 +1260,21 @@ contexts:
         - include: image-ref
         - include: link-ref-literal
         - include: link-ref
+
+  # it is needed to fix the $top_level_main issue
+  # https://github.com/sublimehq/Packages/issues/73#issuecomment-183759677
+  latex_braces:
+    - match: '\{'
+      push:
+        - match: '\}'
+          pop: true
+        - include: latex_braces
+        - include: scope:text.tex.latex
   latex:
     - match: \\\$
     - match: (?=\$\$)
+      with_prototype:
+        - include: latex_braces
       push:
         - meta_scope: text.tex.latex
         - match: (?<=\$\$)
@@ -1273,17 +1285,22 @@ contexts:
         (?=
           \$
           (?:
-            (?<brace> # allow $ inside nested braces
+            \\\\
+            |\\\{
+            |\\\{
+            |(?<brace> # allow $ inside nested braces
               \{
-              (?:[^\{\}]*|\g<brace>)
+              (?:[^{}]|\g<brace>)*
               \}
             )
             |[^\$\{\}]
           )*?
           (?<=\S)\$[^a-zA-Z0-9]
         )
+      with_prototype:
+        - include: latex_braces
       push:
         - meta_scope: text.tex.latex
+        - include: scope:text.tex.latex
         - match: (?<=\S\$)(?=[^a-zA-Z0-9])
           pop: true
-        - include: scope:text.tex.latex

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -1252,17 +1252,29 @@ contexts:
         - include: link-ref-literal
         - include: link-ref
   latex:
+    - match: \\\$
     - match: (?=\$\$)
       push:
         - meta_scope: text.tex.latex
         - match: (?<=\$\$)
           pop: true
         - include: scope:text.tex.latex
-    - match: (?=(\$(?!\$)).*?\S\$)
-      with_prototype:
-        - match: \s$
+    - match: |-
+        (?x)
+        (?=
+          \$
+          (?:
+            (?<brace> # allow $ inside nested braces
+              \{
+              (?:[^\{\}]*|\g<brace>)
+              \}
+            )
+            |[^\$\{\}]
+          )*?
+          (?<=\S)\$[^a-zA-Z0-9]
+        )
       push:
         - meta_scope: text.tex.latex
-        - match: (?<=\S\$|\n)
+        - match: (?<=\S\$)(?=[^a-zA-Z0-9])
           pop: true
         - include: scope:text.tex.latex

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -11,6 +11,11 @@ file_extensions:
 scope: text.html.markdown
 contexts:
   main:
+    - match: (?=(?<!\s)---(\s*coffee|\s*json)?\n$)
+      push: front-matter
+    - match: ""
+      push: body
+  front-matter:
     - match: (?<!\s)---\n$
       push:
         - meta_scope: markup.raw.yaml.front-matter
@@ -32,6 +37,10 @@ contexts:
         - match: ^---\s
           pop: true
         - include: scope:source.json
+    - match: ""
+      pop: true
+      push: body
+  body:
     - match: |-
         (?x)^
         (?= [ ]{,3}>.


### PR DESCRIPTION
This is really two PRs..and I am lazy to split them.

1. improve latex detection, allow, for example, `$\text{$x$}$`

2. fix the separator problem mentioned in https://github.com/jonschlinkert/sublime-markdown-extended/commit/e864385465ea0a2c921f2fd04dacc78850bf1fd. If the first row doesn't contain `---`, it will never include the front matter.