### PR TITLE
Add support for Sublime Text 3 Symbols

### DIFF
--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -915,6 +915,7 @@ contexts:
         1: punctuation.definition.heading.markdown
       push:
         - meta_scope: markup.heading.1.markdown
+        - meta_scope: markup.heading.markdown
         - meta_content_scope: markup.heading.1.markdown
         - match: \s*(#*)$\n?
           captures:

--- a/Syntaxes/Symbol List - Heading.tmPreferences
+++ b/Syntaxes/Symbol List - Heading.tmPreferences
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: Heading</string>
+	<key>scope</key>
+	<string>text.html.markdown markup.heading.markdown</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>symbolTransformation</key>
+		<string>
+		s/\s*#*\s*\z//g;			# strip trailing space and #'s
+		s/(?&lt;=#)#/ /g;			# change all but first # to m-space
+		s/^#( *)\s+(.*)/$1$2/;		# strip first # and space before title
+	</string>
+	</dict>
+	<key>uuid</key>
+	<string>C02A37C1-E770-472F-A13E-358FF0C6AD89</string>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #91

:wave: up until the introduction of the `.sublime-syntax` YAML difinition files I was using my own modified `.tmLanguage` file and the Sublime Symbols for Markdown headers were working (ctrl+R).

Right now I have your entire `.sublime-syntax` file copied in my config location:

```
~/.config/sublime-text-3/Packages$ tree Markdown
Markdown
└── Markdown Extended.sublime-syntax
```

Inside the `Symbol List - Heading.tmPreferences` there is a `markup.heading.markdown` scope used. That file is taken from `[Sublime Text 3 Install Folder]/Packages/Markdown.sublime-package`, no idea if it's needed in your package, because I don't have it installed from the Package Manager.

It works on my end because when using the same folder name `Markdown` as the `Markdown.sublime-package` Sublime just merges the settings from all locations.

You can easily test this - just create a markdown file with a couple of headers in it. The symbols are actually working better than the original Markdown definition, because for example bash comments (starting with `#`) are excluded :)