### PR TITLE
Fixes list highlighting after the first item (see #99 and #135)

### DIFF
--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -1173,6 +1173,10 @@ contexts:
         - meta_scope: meta.paragraph.list.markdown
         - match: ^\s*$
           pop: true
+        - match: '^\s{0,4}([*+-]|([0-9]+)\.)(?=\s)'
+          captures: 
+            1: punctuation.definition.list_item.markdown
+            2: punctuation.definition.list_item.number.markdown
         - include: inline
   raw:
     - match: '(`+)([^`]|(?!(?<!`)\1(?!`))`)*+(\1)'


### PR DESCRIPTION
Issue #135 is simply a duplicate of #99.

Before, only the first item's marker (bullet point or number) would be matched as a list punctuation. Now, once the `list-paragraph` context has been pushed, it checks again at the start of new lines whether it's a list marker.

