### PR TITLE
Basic latex support without `with_prototype`

### DIFF
--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -763,6 +763,7 @@ contexts:
           scope: markup.heading.2.markdown
           captures:
             1: punctuation.definition.heading.markdown
+    - include: latex-display
   html_comment:
     - match: <!--
       captures:
@@ -1029,6 +1030,7 @@ contexts:
     - include: image-ref
     - include: link-ref-literal
     - include: link-ref
+    - include: latex-inline
   italic:
     - match: |-
         (?x)
@@ -1252,3 +1254,19 @@ contexts:
         - include: image-ref
         - include: link-ref-literal
         - include: link-ref
+
+  latex-inline:
+    - match: '(?=\$)'
+      push:
+        - meta_scope: text.tex.latex
+        - match: '(?<=\$)'
+          pop: true
+        - include: scope:text.tex.latex
+
+  latex-display:
+    - match: '(?=\$\$)'
+      push:
+        - meta_scope: text.tex.latex
+        - match: '(?<=\$\$)'
+          pop: true
+        - include: scope:text.tex.latex


### PR DESCRIPTION
See #143 and #141.

Support for latex was dropped due to (if I understand correctly) a change in .sublime-syntax processing that caused it to break. This PR does not revert back to the previous functionality but adds a temporary basic fix for display-math (using double $) and inline-math (using single $).

I am totally new to working with sublime-syntax files, so there might be some obvious improvements. Also, if others could test this fix to see if it breaks something else I think it would be preferable. 

A further improvement that I am not knowledgeable enough to implement is to disable the markdown snippets and completions in the latex scope. This is done for the codeblocks (e.g. if in a python codeblock, I do not have access to the HTML snippets; `b+tab` will do nothing. In regular markdown, because it inherits from HTML, doing `b+tab` will create the bold tab `<b></b>`). If anyone has an idea on how to do this I would appreciate the input!

