### PR TITLE
Add JSX source definition to all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ Note that in order for a language to be highlighted properly, you must have the 
 * `jade`
 * `java`
 * `javascript|js`
-* `json`
 * `json front matter`
+* `json`
+* `jsx`
 * `julia`
 * `less`
 * `ls|livescript|LiveScript`

--- a/Syntaxes/Markdown Extended.JSON-tmLanguage
+++ b/Syntaxes/Markdown Extended.JSON-tmLanguage
@@ -1035,6 +1035,30 @@
             }
         }, 
         {
+            "name": "markup.raw.block.markdown markup.raw.block.fenced.markdown",
+            "end": "(```|~~~|{%\\s*endhighlight\\s*%})\\n",
+            "begin": "(```|~~~|{%\\s*highlight)\\s*(jsx)\\s*((?:linenos\\s*)?%})?$",
+            "patterns": [
+                {
+                    "include": "source.js"
+                },
+                {
+                    "include": "meta.jsx.js"
+                }
+            ],
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.fenced.markdown"
+                },
+                "2": {
+                    "name": "variable.language.fenced.markdown"
+                },
+                "3": {
+                    "name": "punctuation.definition.fenced.markdown"
+                }
+            }
+        },
+        {
             "name": "markup.raw.block.markdown markup.raw.block.fenced.markdown", 
             "end": "(```|{%\\s*endhighlight\\s*%})\\n", 
             "begin": "(```|{%\\s*highlight)\\s*(julia|jl)\\s*((?:linenos\\s*)?%})?$", 
@@ -1721,4 +1745,4 @@
         "md"
     ], 
     "keyEquivalent": "^~M"
-}
+} 

--- a/Syntaxes/Markdown Extended.YAML-tmLanguage
+++ b/Syntaxes/Markdown Extended.YAML-tmLanguage
@@ -189,6 +189,17 @@ patterns:
   - include: source.json
 
 - name: markup.raw.block.markdown markup.raw.block.fenced.markdown
+  begin: (```|~~~|{%\s*highlight)\s*(jsx)\s*((?:linenos\s*)?%})?$
+  end: (```|~~~|{%\s*endhighlight\s*%})\n
+  captures:
+    '1': {name: punctuation.definition.fenced.markdown}
+    '2': {name: variable.language.fenced.markdown}
+    '3': {name: punctuation.definition.fenced.markdown}
+  patterns:
+  - include: source.js
+  - include: meta.jsx.js
+
+- name: markup.raw.block.markdown markup.raw.block.fenced.markdown
   begin: (```|{%\s*highlight)\s*(julia|jl)\s*((?:linenos\s*)?%})?$
   end: (```|{%\s*endhighlight\s*%})\n
   captures:

--- a/Syntaxes/Markdown Extended.sublime-syntax
+++ b/Syntaxes/Markdown Extended.sublime-syntax
@@ -294,6 +294,22 @@ contexts:
             3: punctuation.definition.fenced.markdown
           pop: true
         - include: scope:source.js
+    - match: '(```|~~~|{%\s*highlight)\s*(jsx)\s*((?:linenos\s*)?%})?$'
+      captures:
+        1: punctuation.definition.fenced.markdown
+        2: variable.language.fenced.markdown
+        3: punctuation.definition.fenced.markdown
+      push:
+        - meta_scope: markup.raw.block.markdown markup.raw.block.fenced.markdown
+        - meta_content_scope: source.js
+        - match: '(```|~~~|{%\s*endhighlight\s*%})\n'
+          captures:
+            1: punctuation.definition.fenced.markdown
+            2: variable.language.fenced.markdown
+            3: punctuation.definition.fenced.markdown
+          pop: true
+        - include: scope:source.js
+        - include: scope:meta.jsx.js
     - match: '(```|~~~|{%\s*highlight)\s*(json)\s*((?:linenos\s*)?%})?$'
       captures:
         1: punctuation.definition.fenced.markdown

--- a/Syntaxes/Markdown Extended.tmLanguage
+++ b/Syntaxes/Markdown Extended.tmLanguage
@@ -650,6 +650,43 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(```|~~~|{%\s*highlight)\s*(jsx)\s*((?:linenos\s*)?%})?$</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.fenced.markdown</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.language.fenced.markdown</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.fenced.markdown</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(```|~~~|{%\s*endhighlight\s*%})\n</string>
+			<key>name</key>
+			<string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.js</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>meta.jsx.js</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(```|{%\s*highlight)\s*(julia|jl)\s*((?:linenos\s*)?%})?$</string>
 			<key>captures</key>
 			<dict>


### PR DESCRIPTION
This adds support for JSX, I only could find the scope `meta.jsx.js` in all of my React projects. I'm not sure if that's ok, but I think it's the only way.

Should fix #176, #139, #136 and #104 